### PR TITLE
fix: [TEA-359] hide notifications navigation when flag is disabled

### DIFF
--- a/src/account-settings/JumpNav.jsx
+++ b/src/account-settings/JumpNav.jsx
@@ -3,14 +3,17 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { breakpoints, useWindowSize } from '@openedx/paragon';
 import classNames from 'classnames';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { NavHashLink } from 'react-router-hash-link';
 import Scrollspy from 'react-scrollspy';
 import messages from './AccountSettingsPage.messages';
+import { selectShowPreferences } from '../notification-preferences/data/selectors';
 
 const JumpNav = ({
   intl,
 }) => {
   const stickToTop = useWindowSize().width > breakpoints.small.minWidth;
+  const showNotifications = useSelector(selectShowPreferences());
 
   return (
     <div className={classNames('jump-nav px-2.25', { 'jump-nav-sm position-sticky pt-3': stickToTop })}>
@@ -19,7 +22,7 @@ const JumpNav = ({
           'basic-information',
           'profile-information',
           'social-media',
-          'notifications',
+          ...(showNotifications ? ['notifications'] : []),
           'site-preferences',
           'linked-accounts',
           'delete-account',
@@ -43,11 +46,13 @@ const JumpNav = ({
             {intl.formatMessage(messages['account.settings.section.social.media'])}
           </NavHashLink>
         </li>
-        <li>
-          <NavHashLink to="#notifications">
-            {intl.formatMessage(messages['notification.preferences.notifications.label'])}
-          </NavHashLink>
-        </li>
+        {showNotifications && (
+          <li>
+            <NavHashLink to="#notifications">
+              {intl.formatMessage(messages['notification.preferences.notifications.label'])}
+            </NavHashLink>
+          </li>
+        )}
         <li>
           <NavHashLink to="#site-preferences">
             {intl.formatMessage(messages['account.settings.section.site.preferences'])}

--- a/src/account-settings/test/JumpNav.test.jsx
+++ b/src/account-settings/test/JumpNav.test.jsx
@@ -72,4 +72,40 @@ describe('JumpNav', () => {
 
     expect(await screen.findByText('Delete My Account')).toBeVisible();
   });
+
+  it('should not render notifications link when showPreferences is false', async () => {
+    store = configureStore({
+      notificationPreferences: {
+        showPreferences: false,
+      },
+    });
+
+    render(
+      <IntlProvider locale="en">
+        <AppProvider store={store}>
+          <IntlJumpNav {...props} />
+        </AppProvider>
+      </IntlProvider>,
+    );
+
+    expect(screen.queryByText('Notifications')).toBeNull();
+  });
+
+  it('should render notifications link when showPreferences is true', async () => {
+    store = configureStore({
+      notificationPreferences: {
+        showPreferences: true,
+      },
+    });
+
+    render(
+      <IntlProvider locale="en">
+        <AppProvider store={store}>
+          <IntlJumpNav {...props} />
+        </AppProvider>
+      </IntlProvider>,
+    );
+
+    expect(await screen.findByText('Notifications')).toBeVisible();
+  });
 });


### PR DESCRIPTION
### Description

https://youtrack.raccoongang.com/issue/TEA-359

#### Screenshots/sandbox (optional):

<img width="1491" height="791" alt="Знімок екрана 2026-02-10 о 20 48 02" src="https://github.com/user-attachments/assets/e2df7408-4c5d-488e-b1b0-09835a37264f" />

<img width="1487" height="839" alt="Знімок екрана 2026-02-12 о 16 42 03" src="https://github.com/user-attachments/assets/0162cfc3-e2c6-4222-9fae-2e58e3bc1cdd" />
